### PR TITLE
Fix require_once.

### DIFF
--- a/question/q001/q001.php
+++ b/question/q001/q001.php
@@ -4,7 +4,7 @@
  * User: fortegp05
  */
 
-require_once './Wareki.php';
+require_once __DIR__ . '/Wareki.php';
 
 if ($argc < 2) return Wareki::ERROR_MSG;
 

--- a/tests/TestWareki.php
+++ b/tests/TestWareki.php
@@ -6,7 +6,7 @@
 
 use \PHPUnit\Framework\TestCase;
 
-require_once(__DIR__ . '/../question/q001/Wareki.php');
+require_once __DIR__ . '/../question/q001/Wareki.php';
 
 class TestWareki extends TestCase
 {


### PR DESCRIPTION
ファイルの読み込みに相対パスを使用するとカレントディレクトリの影響を受けるので、絶対パスで書きました。
こちらをご参考にしていただければー。
https://blog.leko.jp/post/fix-require-relative-path-of-php/

