### PR TITLE
自分ならこう書きます（publicなテストだけを対応）

### DIFF
--- a/tests/TestWareki.php
+++ b/tests/TestWareki.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: fortegp05
- */
 
 use \PHPUnit\Framework\TestCase;
 
@@ -10,32 +6,56 @@ require_once(__DIR__ . '/../question/q001/Wareki.php');
 
 class TestWareki extends TestCase
 {
+    private $wareki;
     const RESULT_MSG = 'RESULT';
     const INPUT = 'INPUT';
-    private $testData = [
-        '日付じゃない(文字列)' => [TestWareki::RESULT_MSG => Wareki::ERROR_MSG, TestWareki::INPUT => 'HOGEHOGE'],
-        '日付じゃない(数値)' => [TestWareki::RESULT_MSG => Wareki::ERROR_MSG, TestWareki::INPUT => '00000000'],
-        'あり得ない日付' => [TestWareki::RESULT_MSG => Wareki::ERROR_MSG, TestWareki::INPUT => '20180229'],
-        '江戸' => [TestWareki::RESULT_MSG => Wareki::ERROR_MSG, TestWareki::INPUT => '16030101'],
-        '江戸終了境界' => [TestWareki::RESULT_MSG => Wareki::ERROR_MSG, TestWareki::INPUT => '18680124'],
-        '明治開始境界' => [TestWareki::RESULT_MSG => Wareki::MEIJI, TestWareki::INPUT => '18680125'],
-        '明治終了境界' => [TestWareki::RESULT_MSG => Wareki::MEIJI, TestWareki::INPUT => '19120729'],
-        '大正開始境界' => [TestWareki::RESULT_MSG => Wareki::TAISYO, TestWareki::INPUT => '19120730'],
-        '大正終了境界' => [TestWareki::RESULT_MSG => Wareki::TAISYO, TestWareki::INPUT => '19261224'],
-        '昭和開始境界' => [TestWareki::RESULT_MSG => Wareki::SYOWA, TestWareki::INPUT => '19261225'],
-        '昭和終了境界' => [TestWareki::RESULT_MSG => Wareki::SYOWA, TestWareki::INPUT => '19890107'],
-        '平成開始境界' => [TestWareki::RESULT_MSG => Wareki::HEISEI, TestWareki::INPUT => '19890108'],
-        '平成終了境界' => [TestWareki::RESULT_MSG => Wareki::HEISEI, TestWareki::INPUT => '20190420'],
-        '新年号開始境界' => [TestWareki::RESULT_MSG => Wareki::NEW_GENGO, TestWareki::INPUT => '20190501'],
-    ];
 
-    public function test_wareki()
+    public function setUp()
     {
-        $wareki = new Wareki();
-        echo PHP_EOL;
-        foreach ($this->testData as $title => $data) {
-            echo $title . ' RESULT=' . $wareki->getWareki($data[TestWareki::INPUT]) . PHP_EOL;
-            $this->assertTrue($wareki->getWareki($data[TestWareki::INPUT]) === $data[TestWareki::RESULT_MSG]);
-        }
+        $this->wareki = new Wareki();
     }
+
+    /**
+     * @dataProvider getWarekiDataProvider
+     */
+    public function testGetWareki($text, $expected, $input)
+    {
+        $this->assertSame($expected, $this->wareki->getWareki($input), $text);
+    }
+
+    /**
+     * あえて失敗するテストも書いておきますね！
+     * @dataProvider getWarekiDataProviderFailure
+     *
+     */
+    public function testGetWarekiFailure($text, $expected, $input)
+    {
+        $this->assertSame($expected, $this->wareki->getWareki($input), $text);
+    }
+    /**
+     * 
+     */
+    public function getWarekiDataProvider()
+    {
+        // 説明テキスト、期待される出力、関数への入力値
+        return [
+            ['日付じゃない(文字列)' , Wareki::ERROR_MSG, 'HOGEHOGE'],
+            ['日付じゃない(数値)'   , Wareki::ERROR_MSG, '00000000'],
+            ['平成開始境界'         , Wareki::HEISEI,    '19890108'],
+            // 省略
+        ];
+    }
+    /**
+     * 
+     */
+    public function getWarekiDataProviderFailure()
+    {
+        // 説明テキスト、期待される出力、関数への入力値
+        return [
+            ['日付じゃない(文字列)' , Wareki::HEISEI,   'HOGEHOGE'],
+            ['平成開始境界'         , Wareki::MEIJI,    '19890108'],
+            // 省略
+        ];
+    }
+
 }


### PR DESCRIPTION
assertSameの第3引数に対してテストのメッセージを記載
echo はユニットテスト内に書くべきではないので、失敗した場合には

```
1) TestWareki::testGetWarekiFailure with data set #0 ('日付じゃない(文字列)', 'H', 'HOGEHOGE')
日付じゃない(文字列)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'H'
+'ERROR'

/Users/tetsunosuke.ito/work/php/laracon/Laracon/tests/TestWareki.php:33

2) TestWareki::testGetWarekiFailure with data set #1 ('平成開始境界', 'M', '19890108')
平成開始境界
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'M'
+'H'
```

このように出るようになります。