### PR TITLE
シンプルに例外を出すパターンのテスト

### DIFF
--- a/question/qqqq/ThrowException.php
+++ b/question/qqqq/ThrowException.php
@@ -14,7 +14,7 @@ class ThrowException
     /**
      * 入力された文字列を文字列で分割しようとはしているが...？
      */
-    public function callExplodeThrowsException(string $str): string
+    public function callExplodeThrowsException(string $str): array
     {
         if (strlen($str) <= 1) {
             // 一文字しかないので引数が不正として例外にする

--- a/question/qqqq/ThrowException.php
+++ b/question/qqqq/ThrowException.php
@@ -16,19 +16,15 @@ class ThrowException
      */
     public function callExplodeThrowsException(string $str): string
     {
-        try {
-            if (strlen($str) <= 1) {
-                // 一文字しかないので引数が不正として例外にする
-                throw new \Exception(self::MESSAGE_ARGUMENT_IS_TOO_SHORT);
-            }
-            // explode ( string $delimiter , string $string [, int $limit = PHP_INT_MAX ] ) : array
-
-            // これでは明らかに引数が足らない
-            // 実際には ArgumentCountError が発生する
-            return explode($str); 
-        } catch (\Exception $e) {
-            throw $e;
+        if (strlen($str) <= 1) {
+            // 一文字しかないので引数が不正として例外にする
+            throw new \Exception(self::MESSAGE_ARGUMENT_IS_TOO_SHORT);
         }
+        // explode ( string $delimiter , string $string [, int $limit = PHP_INT_MAX ] ) : array
+
+        // これでは明らかに引数が足らない
+        // 実際には ArgumentCountError が発生する
+        return explode($str); 
     }
 
     public function callExplodeReturnTypeIsBad(string $str): string

--- a/question/qqqq/ThrowException.php
+++ b/question/qqqq/ThrowException.php
@@ -1,0 +1,52 @@
+<?php
+
+// メソッド呼び出し時に例外が出るように定義
+declare(strict_types = 1);
+
+namespace LaravelJpCon\qqqq;
+
+
+class ThrowException
+{
+
+    const MESSAGE_ARGUMENT_IS_TOO_SHORT = 'can not explode because $str is too short';
+
+    /**
+     * 入力された文字列を文字列で分割しようとはしているが...？
+     */
+    public function callExplodeThrowsException(string $str): string
+    {
+        try {
+            if (strlen($str) <= 1) {
+                // 一文字しかないので引数が不正として例外にする
+                throw new \Exception(self::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+            }
+            // explode ( string $delimiter , string $string [, int $limit = PHP_INT_MAX ] ) : array
+
+            // これでは明らかに引数が足らない
+            // 実際には ArgumentCountError が発生する
+            return explode($str); 
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    public function callExplodeReturnTypeIsBad(string $str): string
+    {
+        if (strlen($str) <= 1) {
+            // 一文字しかないので引数が不正として例外にする
+            throw new \Exception(self::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+        }
+
+        return explode($str, ","); 
+    }
+    public function callExplodeNormally(string $str): array
+    {
+        if (strlen($str) <= 1) {
+            // 一文字しかないので引数が不正として例外にする
+            throw new \Exception(self::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+        }
+
+        return explode(",", $str);
+    }
+}

--- a/tests/ThrowExceptionTest.php
+++ b/tests/ThrowExceptionTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ */
+
+use LaravelJpCon\qqqq\ThrowException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ */
+class ThrowExceptionTest extends TestCase
+{
+    private $obj;
+
+    public function setUp()
+    {
+        $this->obj = new ThrowException();
+    }
+
+    public function testExplodeThrowsException()
+    {
+        $this->expectException(\ArgumentCountError::class);
+        $this->obj->callExplodeThrowsException("test");
+    }
+    public function testExplodeThrowsException_argumentStrIsTooShort()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(ThrowException::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+        $this->obj->callExplodeThrowsException("t");
+    }
+
+    public function testExplodeReturnTypeIsBad_argumentStrIsTooShort()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(ThrowException::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+        $this->obj->callExplodeReturnTypeIsBad("t");
+    }
+    public function testExplodeReturnTypeIsBad_SignatureIsBad()
+    {
+        $expected = ['a', 'b'];
+        $this->expectException(\TypeError::class);
+        $this->assertSame($expected, $this->obj->callExplodeReturnTypeIsBad("a,b"));
+    }
+
+    public function testExplodeNormally_argumentStrIsTooShort()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(ThrowException::MESSAGE_ARGUMENT_IS_TOO_SHORT);
+        $this->obj->callExplodeNormally("t");
+    }
+    public function testExplodeNormally()
+    {
+        $expected = ['a', 'b', 'c'];
+        $this->assertSame($expected, $this->obj->callExplodeNormally("a,b,c"));
+    }
+}


### PR DESCRIPTION
エラー・例外発生に関してのテストを追加しました。

- 明示的に 例外を throw するパターン
- 関数呼び出し時に自然発生しうる標準エラー
    - 標準関数の呼び出しにおける引数不足
    - 独自関数のシグネチャに関するエラー

expecteExceptionMessageがあったりなかったりするのはまあどっちでもいいかなとは思っている。

フォルダ名とか名前空間がqqqqになっているのは問題番号に適当に併せてください